### PR TITLE
fix(cicd): ignore SETUPTOOLS_SCM_PRETEND_VERSION env during build step

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,19 @@
 from pathlib import Path
 from Cython.Build import cythonize
 from setuptools import find_packages, setup
+import os
+
+# -----------------------------------------------------------------------------
+# Ignore SETUPTOOLS_SCM_PRETEND_VERSION for cchecksum builds.
+# This environment variable is sometimes set by downstream projects (e.g., for
+# dry runs or CI version overrides). If it is present during a dependency build,
+# it can cause cchecksum to be built with the wrong version metadata, leading to
+# install failures and version mismatches on PyPI. We only want to use this env
+# var if we are building cchecksum as the top-level project, not as a dependency.
+# -----------------------------------------------------------------------------
+if os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION"):
+    if Path.cwd().resolve() != Path(__file__).parent.resolve():
+        del os.environ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 
 with open("requirements.txt", "r") as f:
     requirements = list(map(str.strip, f.read().split("\n")))[:-1]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
+import os
 from pathlib import Path
 from Cython.Build import cythonize
 from setuptools import find_packages, setup
-import os
 
 # -----------------------------------------------------------------------------
 # Always ignore SETUPTOOLS_SCM_PRETEND_VERSION for cchecksum builds.

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,14 @@ from setuptools import find_packages, setup
 import os
 
 # -----------------------------------------------------------------------------
-# Ignore SETUPTOOLS_SCM_PRETEND_VERSION for cchecksum builds.
-# This environment variable is sometimes set by downstream projects (e.g., for
-# dry runs or CI version overrides). If it is present during a dependency build,
-# it can cause cchecksum to be built with the wrong version metadata, leading to
-# install failures and version mismatches on PyPI. We only want to use this env
-# var if we are building cchecksum as the top-level project, not as a dependency.
+# Always ignore SETUPTOOLS_SCM_PRETEND_VERSION for cchecksum builds.
+# This environment variable is sometimes set by downstream projects at build time.
+# It can cause cchecksum to be built with the wrong version metadata, leading to
+# install failures. We never use this env var for cchecksum, so it is safe for us
+# to remove it from the cchecksum build environment.
 # -----------------------------------------------------------------------------
-if os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION"):
-    if Path.cwd().resolve() != Path(__file__).parent.resolve():
-        del os.environ["SETUPTOOLS_SCM_PRETEND_VERSION"]
+if "SETUPTOOLS_SCM_PRETEND_VERSION" in os.environ:
+    del os.environ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 
 with open("requirements.txt", "r") as f:
     requirements = list(map(str.strip, f.read().split("\n")))[:-1]


### PR DESCRIPTION
some downstream dependencies use SETUPTOOLS_SCM_PRETEND_VERSION at build time, and this can occasionally leak to cchecksum if cchecksum is a buildtime dep of the same

This PR ignores SETUPTOOLS_SCM_PRETEND_VERSION while cchecksum is building so as to avoid any conflicts